### PR TITLE
Update go-lint to v2

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -8,6 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
           version: v1.30


### PR DESCRIPTION
See: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/